### PR TITLE
Add new deployment scripts

### DIFF
--- a/deploy-new/.django.secrets
+++ b/deploy-new/.django.secrets
@@ -1,0 +1,4 @@
+DJANGO_SECRET_KEY=your-django-secret
+DJANGO_SUPERUSER_USERNAME=your-django-username
+DJANGO_SUPERUSER_PASSWORD=your-django-password
+DJANGO_SUPERUSER_EMAIL=your-django-email

--- a/deploy-new/build-and-deploy.sh
+++ b/deploy-new/build-and-deploy.sh
@@ -1,0 +1,146 @@
+#!/bin/bash
+
+# Create and Generate Service Account Key, save it as 'sa_key.json' in the root folder with the following IAM Permissions:
+# Artifact Registry Administrator
+# Service Account User (roles/iam.serviceAccountUser)
+# Cloud Run Developer (roles/run.developer) on the Cloud Run service
+# Artifact Registry Administrator
+# Cloud Build Service Account
+# Cloud Run Admin
+# Secret Manager Secret Accessor (roles/secretmanager.secretAccessor)
+# Service Account User
+# Storage Object Creator
+# Storage Object Viewer
+#
+# You can also using your own user that has Owner/Editor permissions
+# Comment `gcloud auth login --cred-file="$PARENT_DIR/sa_key.json"` command below
+# Make sure you have already setup gcloud SDK (gcloud CLI) and login with your account
+# Documentation : https://cloud.google.com/sdk/docs/authorizing
+
+# Define required environment variables for this script
+required_vars=("GCP_PROJECT_ID" "GCP_REGION" "AR_LOCATION" "SERVICE_ACCOUNT_NAME" "SERVICE_NAME")
+
+# Set Path
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Validate environment variables or exit
+source "$SCRIPT_DIR/common.sh"
+
+# Section 1: Setup gcloud CLI using Service Account Key
+show_section_header "Setting up gcloud CLI permissions using Service Account..."
+show_loading "Configuring gcloud CLI with Service Account"
+gcloud auth activate-service-account $SERVICE_ACCOUNT_NAME@$GCP_PROJECT_ID.iam.gserviceaccount.com \
+    --key-file="$SCRIPT_DIR/$SERVICE_ACCOUNT_NAME.json" \
+    --project=$GCP_PROJECT_ID
+
+if [ $? -ne 0 ]; then
+    print_error "Configure gcloud CLI with Service Account" "Failed"
+    exit 1
+fi
+print_success "Configure gcloud CLI with Service Account" "Success"
+
+# Get Project Number
+show_loading "Get GCP Project number"
+PROJECT_NUMBER=$(gcloud projects describe $GCP_PROJECT_ID --format="value(projectNumber)")
+if [ $? -ne 0 ]; then
+  print_error "Retrieving project number" "Failed"
+  exit 1
+fi
+print_success "Project number: $PROJECT_NUMBER" "Retrieved"
+
+
+# Section 2: Setup necessary permissions
+# Setup MySQL databsase
+show_section_header "Setup Cloud SQL for MySQL database..."   
+show_loading "Creating MySQL database..."
+if ! gcloud sql databases describe $SERVICE_NAME-$PROJECT_NUMBER-db --instance=$SERVICE_NAME-$PROJECT_NUMBER-mysql > /dev/null 2>&1; then
+    gcloud sql databases create $SERVICE_NAME-$PROJECT_NUMBER-db \
+        --instance=$SERVICE_NAME-$PROJECT_NUMBER-mysql
+    if [ $? -ne 0 ]; then
+        print_error "$SERVICE_NAME-$PROJECT_NUMBER-db database creation" "Failed"
+    else
+        # Set root password
+        show_loading "Creating root password..."
+        gcloud sql users set-password root \
+            --host=% \
+            --instance=$SERVICE_NAME-$PROJECT_NUMBER-mysql \
+            --password=$MYSQL_ROOT_PASSWORD
+        if [ $? -ne 0 ]; then
+            print_error "$SERVICE_NAME-$PROJECT_NUMBER-mysql set root password" "Failed"
+        else
+            print_success "$SERVICE_NAME-$PROJECT_NUMBER-mysql set root password" "Success"
+        fi
+    fi
+else
+    print_warning "$SERVICE_NAME-$PROJECT_NUMBER-db database already exists" "Skipped"
+fi
+
+# Setup MySQL user
+show_loading "Creating MySQL user..."
+if gcloud sql databases describe $SERVICE_NAME-$PROJECT_NUMBER-db --instance=$SERVICE_NAME-$PROJECT_NUMBER-mysql && ! gcloud sql users describe $SERVICE_NAME-$PROJECT_NUMBER-db-user --instance=$SERVICE_NAME-$PROJECT_NUMBER-mysql > /dev/null 2>&1; then
+    gcloud sql users create $SERVICE_NAME-$PROJECT_NUMBER-db-user \
+        --host=% \
+        --instance=$SERVICE_NAME-$PROJECT_NUMBER-mysql \
+        --password=$MYSQL_USER_PASSWORD
+    if [ $? -ne 0 ]; then
+        print_error "MySQL User creation" "Failed"
+    else
+        print_success "MySQL User creation" "Success"
+    fi
+else
+    print_warning "MySQL User already exists" "Skipped"
+fi
+
+
+# Create secret in Secret Manager
+show_section_header "Create secrets for Application..." 
+create_secret "MYSQL_HOST" "/cloudsql/$GCP_PROJECT_ID:$GCP_REGION:$SERVICE_NAME-$PROJECT_NUMBER-mysql"
+create_secret "MYSQL_DATABASE" "$SERVICE_NAME-$PROJECT_NUMBER-db"
+create_secret "MYSQL_USER" "$SERVICE_NAME-$PROJECT_NUMBER-db-user"
+create_secret "MYSQL_PASSWORD" "$MYSQL_USER_PASSWORD"
+
+show_loading "Importing all secrets to Secret Manager..."
+import_secret_env "$SCRIPT_DIR/.django.secrets"
+
+# Section 3: Building & submit containers
+show_section_header "Building & submit containers..."   
+show_loading "Authenticating Docker to Artifact Registry..."
+gcloud auth configure-docker $AR_LOCATION-docker.pkg.dev
+if [ $? -ne 0 ]; then
+    print_error "Authenticating Docker" "Failed"
+    exit 1
+fi
+print_success "Docker authenticated to Artifact Registry" "Success"
+
+# Build container and submit to Artifact Registry repository
+show_loading "Building container and submit to Artifact Registry..."
+gcloud builds submit --dir=$PARENT_DIR/Dockerfile \
+    --tag $AR_LOCATION-docker.pkg.dev/$GCP_PROJECT_ID/$SERVICE_NAME-$PROJECT_NUMBER-repo/$SERVICE_NAME:latest \
+    --region $GCP_REGION
+if [ $? -ne 0 ]; then
+    print_error "Building & submitting container" "Failed"
+    exit 1
+fi
+print_success "Building & submitting container" "Success"
+
+# Section 4: Deploy to Cloud Run
+show_section_header "Deploy container to Cloud Run"
+show_loading "Deploying container to Cloud Run..."
+gcloud run deploy $SERVICE_NAME \
+    --image $AR_LOCATION-docker.pkg.dev/$GCP_PROJECT_ID/$SERVICE_NAME-$PROJECT_NUMBER-repo/$SERVICE_NAME:latest \
+    --region $GCP_REGION \
+    --service-account $SERVICE_ACCOUNT_NAME@$GCP_PROJECT_ID.iam.gserviceaccount.com \
+    --port 8000 \
+    --add-cloudsql-instances=$GCP_PROJECT_ID:$GCP_REGION:$SERVICE_NAME-$PROJECT_NUMBER-mysql \
+    --set-env-vars ^,^DJANGO_ENV=$DJANGO_ENV,GCP_PROJECT_ID=$GCP_PROJECT_ID,GCP_BUCKET_NAME=$SERVICE_NAME-$PROJECT_NUMBER-bucket \
+    --set-env-vars ^@^DJANGO_ALLOWED_HOSTS=$DJANGO_ALLOWED_HOSTS@DJANGO_CSRF_TRUSTED_ORIGINS=$DJANGO_CSRF_TRUSTED_ORIGINS \
+    --set-secrets ^,^DJANGO_SECRET_KEY=DJANGO_SECRET_KEY:latest,DJANGO_SUPERUSER_USERNAME=DJANGO_SUPERUSER_USERNAME:latest,DJANGO_SUPERUSER_PASSWORD=DJANGO_SUPERUSER_PASSWORD:latest,DJANGO_SUPERUSER_EMAIL=DJANGO_SUPERUSER_EMAIL:latest,MYSQL_HOST=MYSQL_HOST:latest,MYSQL_DATABASE=MYSQL_DATABASE:latest,MYSQL_USER=MYSQL_USER:latest,MYSQL_PASSWORD=MYSQL_PASSWORD:latest \
+    --min-instances 1 \
+    --allow-unauthenticated
+if [ $? -ne 0 ]; then
+    print_error "Deploying to Cloud Run" "Failed"
+    exit 1
+fi
+print_success "Deploying to Cloud Run" "Success"
+
+echo -e "\nBuild and Deploy to Cloud Run completed.\n"

--- a/deploy-new/common.sh
+++ b/deploy-new/common.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+
+# Source the functions.sh file to load the functions
+source "$SCRIPT_DIR/functions.sh"
+
+# Set Path
+PARENT_DIR="$(dirname "$SCRIPT_DIR")"
+
+# Initialize an associative array to track which required variables are found
+declare -A found_vars
+for var in "${required_vars[@]}"; do
+  found_vars["$var"]=0
+done
+
+# Path to the .env file
+env_file="$PARENT_DIR/.env"
+
+# Read the .env file to check for required variables, adding a newline to ensure the last line is read
+while IFS= read -r line; do
+  # Skip empty lines and lines starting with #
+  [[ -z "$line" || "$line" == \#* ]] && continue
+
+  # Extract the variable name from the line
+  var_name=$(echo "$line" | cut -d '=' -f 1)
+
+  # Check if the variable is in the required list
+  if [[ " ${required_vars[*]} " == *" $var_name "* ]]; then
+    found_vars["$var_name"]=1
+  fi
+done < <(cat "$env_file"; echo)
+
+# Check if any required variables are missing
+missing_vars=()
+for var in "${required_vars[@]}"; do
+  if [[ ${found_vars["$var"]} -eq 0 ]]; then
+    missing_vars+=("$var")
+  fi
+done
+
+# Output the result and exit if any required variables are missing
+if [[ ${#missing_vars[@]} -ne 0 ]]; then
+  echo "The following required variables are missing in $env_file:"
+  for var in "${missing_vars[@]}"; do
+    echo "$var"
+  done
+  exit 1
+fi
+
+# If all required variables are present, export all variables from the .env file, adding a newline to ensure the last line is read
+while IFS= read -r line; do
+  # Skip empty lines and lines starting with #
+  [[ -z "$line" || "$line" == \#* ]] && continue
+
+  # Validate that the line contains an equal sign and has a non-empty variable name
+  if [[ "$line" == *=* ]]; then
+    var_name=$(echo "$line" | cut -d '=' -f 1)
+    var_value=$(echo "$line" | cut -d '=' -f 2-)
+
+    # Export the variable to the environment only if var_name is not empty
+    if [[ -n "$var_name" ]]; then
+      export "$var_name=$var_value"
+    fi
+  fi
+done < <(cat "$env_file"; echo)
+
+echo "All required variables are present in $env_file and have been exported to the environment."

--- a/deploy-new/create-service-account.sh
+++ b/deploy-new/create-service-account.sh
@@ -1,0 +1,100 @@
+# Define required environment variables for this script
+required_vars=("GCP_PROJECT_ID" "SERVICE_ACCOUNT_NAME")
+
+# Set Path
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Validate environment variables or exit
+source "$SCRIPT_DIR/common.sh"
+
+# Set your variables
+KEY_FILE_PATH="$SCRIPT_DIR/$SERVICE_ACCOUNT_NAME.json"
+
+# Authenticate with Google Cloud
+show_section_header "Setting up gcloud CLI permissions using your own account..."
+show_loading "Configuring gcloud CLI with your own account..."
+gcloud auth login
+if [ $? -ne 0 ]; then
+    print_error "Configure gcloud CLI with Service Account" "Failed"
+    exit 1
+else
+    print_success "Configure gcloud CLI with Service Account" "Success"
+fi
+
+show_loading "Setting GCP Poject..."
+gcloud config set project $GCP_PROJECT_ID
+if [ $? -ne 0 ]; then
+    print_error "Setting GCP Project" "Failed"
+    exit 1
+else
+    print_success "Setting GCP Project" "Success"
+fi
+
+show_loading "Enable required IAM API..."
+gcloud services enable iam.googleapis.com
+if [ $? -ne 0 ]; then
+    print_error "Enabling IAM API" "Failed"
+    exit 1
+else
+    print_success "Enabling IAM API" "Success"
+fi
+
+
+# Add necessary IAM permissions for service account
+show_section_header "Setup service account and permissions..."
+show_loading "Creating service account..."
+if ! gcloud iam service-accounts describe $SERVICE_ACCOUNT_NAME@$GCP_PROJECT_ID.iam.gserviceaccount.com > /dev/null 2>&1; then
+    gcloud iam service-accounts create $SERVICE_ACCOUNT_NAME \
+    --description="Service account for automatic deployment to google cloud" \
+    --display-name="$SERVICE_ACCOUNT_NAME"
+    if [ $? -ne 0 ]; then
+        print_error "Service account creation" "Failed"
+    else
+        print_success "Service account creation" "Success"
+    fi
+else
+    print_warning "$SERVICE_ACCOUNT_NAME@$GCP_PROJECT_ID.iam.gserviceaccount.com already exists" "Skipped"
+fi
+
+show_loading "Add necessary IAM permissions for service account..."
+roles=(
+    "roles/viewer"
+    "roles/artifactregistry.admin"
+    "roles/cloudbuild.builds.builder"
+    "roles/run.admin"
+    "roles/cloudsql.admin"
+    "roles/compute.instanceAdmin.v1"
+    "roles/compute.networkAdmin"
+    "roles/compute.securityAdmin"
+    "roles/dns.admin"
+    "roles/secretmanager.admin"
+    "roles/iam.serviceAccountUser"
+    "roles/serviceusage.serviceUsageAdmin"
+    "roles/storage.admin"
+)
+for role in "${roles[@]}"; do
+    if [[ $(gcloud projects get-iam-policy $GCP_PROJECT_ID --flatten="bindings[].members" --format='table(bindings.role)' --filter="bindings.members:$SERVICE_ACCOUNT_NAME@$GCP_PROJECT_ID.iam.gserviceaccount.com AND bindings.role:$role") == ROLE* ]] then
+        print_warning "$role role already exists" "Skipped"
+    else
+        gcloud projects add-iam-policy-binding $GCP_PROJECT_ID \
+        --member="serviceAccount:$SERVICE_ACCOUNT_NAME@$GCP_PROJECT_ID.iam.gserviceaccount.com" \
+        --role="$role" \
+        --quiet
+        if [ $? -ne 0 ]; then
+            print_error "$role added to Service Account" "Failed"
+        else
+            print_success "$role added to Service Account" "Success"
+        fi
+    fi
+done
+
+
+# Create and download the service account key
+show_loading "Create and download the service account key..."
+gcloud iam service-accounts keys create $KEY_FILE_PATH \
+    --iam-account=$SERVICE_ACCOUNT_NAME@$GCP_PROJECT_ID.iam.gserviceaccount.com
+if [ $? -ne 0 ]; then
+    print_error "Service account key creation" "Failed"
+else
+    print_success "Service account key creation" "Success"
+fi

--- a/deploy-new/functions.sh
+++ b/deploy-new/functions.sh
@@ -1,0 +1,95 @@
+# Function to print error message
+print_error() {
+    local item="$1"    # Item name, e.g., API name
+    local status="$2"  # Status message, e.g., "Enable fail."
+    
+    # Print formatted error message
+    printf "\033[31m%-5s\033[0m %-60s %-20s\n" "[Error]" "$item" "$status"
+}
+
+# Function to print success message
+print_success() {
+    local item="$1"    # Item name, e.g., API name
+    local status="$2"  # Status message, e.g., "Enable success"
+    
+    # Print formatted success message
+    printf "\033[32m%-5s\033[0m %-60s %-20s\n" "[Success]" "$item" "$status"
+}
+
+# Function to print warning message
+print_warning() {
+    local item="$1"    # Item name, e.g., API name
+    local status="$2"  # Status message, e.g., "Skipped"
+    
+    # Print formatted success message
+    printf "\033[33m%-5s\033[0m %-60s %-20s\n" "[Warning]" "$item" "$status"
+}
+
+# Function to show section header
+show_section_header() {
+    local section_name="$1"  # Section name
+    
+    # Print section header
+    printf "\n\033[1m%s\033[0m\n" "$section_name"
+    echo "--------------------------------------------"
+}
+
+# Function to show loading indicator
+show_loading() {
+    local task="$1"    # Task description
+    
+    # Print formatted loading message
+    echo -n "➤ $task... "
+    printf "\033[34m[Loading]\033[0m"
+    echo -ne "\033[0m "
+    echo
+}
+
+# Function to import secret to Secret Manager
+import_secret_env() {
+  local file_path="$1"
+  
+  if [[ ! -f "$file_path" ]]; then
+    echo "File not found: $file_path"
+    return 1
+  fi
+
+  while IFS='=' read -r key value; do
+    if [[ -n "$key" && -n "$value" ]]; then
+        if ! gcloud secrets describe $key > /dev/null 2>&1; then
+            echo -n "$value" | gcloud secrets create "$key" \
+                --replication-policy="automatic" \
+                --data-file=-
+            if [ $? -ne 0 ]; then
+                print_error "Secret '$key' creation." "Failed"
+            else
+                print_success "Secret '$key' creation." "Success"
+            fi
+        else
+            print_warning "'$key' secret already exists" "Skipped"
+        fi
+    else
+      print_error "Invalid line: $key=$value" "Skipping"
+    fi
+  done < <(cat "$file_path"; echo)
+}
+
+# Function to create secret in Secret Manager
+create_secret() {
+    local key="$1"
+    local value="$2"
+    
+    show_loading "Creating secrets for $key..."
+    if ! gcloud secrets describe $key > /dev/null 2>&1; then
+        echo -n "$value" | gcloud secrets create "$key" \
+            --replication-policy="automatic" \
+            --data-file=-
+        if [ $? -ne 0 ]; then
+            print_error "$key secret creation" "Failed"
+        else
+            print_success "$key secret" "Created"
+        fi
+    else
+        print_warning "$key secret already exists" "Skipped"
+    fi
+}

--- a/deploy-new/http-to-https.yaml
+++ b/deploy-new/http-to-https.yaml
@@ -1,0 +1,5 @@
+kind: compute#urlMap
+name: http-to-https-redirect
+defaultUrlRedirect:
+  redirectResponseCode: MOVED_PERMANENTLY_DEFAULT
+  httpsRedirect: True

--- a/deploy-new/setup-gcp-environment.sh
+++ b/deploy-new/setup-gcp-environment.sh
@@ -1,0 +1,122 @@
+#!/bin/bash
+
+# Please make sure you have enable billing for your project
+# Please make sure you enable Service Usage API https://console.cloud.google.com/project/_/apis/library/serviceusage.googleapis.com
+# Before running this script
+
+# Define required environment variables for this script
+required_vars=("GCP_PROJECT_ID" "GCP_REGION" "AR_LOCATION" "GCP_DNS_ZONE_NAME" "GCP_BUCKET_LOCATION" "SERVICE_ACCOUNT_NAME")
+
+# Set Path
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Validate environment variables or exit
+source "$SCRIPT_DIR/common.sh"
+
+
+# Section 1: Setup gcloud CLI using Service Account Key
+show_section_header "Setting up gcloud CLI permissions using Service Account..."
+show_loading "Configuring gcloud CLI with Service Account"
+gcloud auth activate-service-account $SERVICE_ACCOUNT_NAME@$GCP_PROJECT_ID.iam.gserviceaccount.com \
+    --key-file="$SCRIPT_DIR/$SERVICE_ACCOUNT_NAME.json" \
+    --project=$GCP_PROJECT_ID
+
+if [ $? -ne 0 ]; then
+    print_error "Configure gcloud CLI with Service Account" "Failed"
+    exit 1
+fi
+print_success "Configure gcloud CLI with Service Account" "Success"
+
+
+# Section 2: Enable necessary Google Cloud APIs
+show_section_header "Enabling necessary Google Cloud APIs..."
+show_loading "Enabling Google Cloud APIs"
+apis=(
+    "cloudresourcemanager.googleapis.com"
+    "artifactregistry.googleapis.com"
+    "cloudbuild.googleapis.com"
+    "run.googleapis.com"
+    "secretmanager.googleapis.com"
+    "sqladmin.googleapis.com"
+    "sql-component.googleapis.com"
+    "compute.googleapis.com"
+    "dns.googleapis.com"
+)
+for api in "${apis[@]}"; do
+    gcloud services enable "$api"
+    if [ $? -ne 0 ]; then
+        print_error "$api" "Failed"
+    else
+        print_success "$api" "Enabled"
+    fi
+done
+echo
+
+# Get Project Number
+show_loading "Get GCP Project number"
+PROJECT_NUMBER=$(gcloud projects describe $GCP_PROJECT_ID --format="value(projectNumber)")
+if [ $? -ne 0 ]; then
+  print_error "Retrieving project number" "Failed"
+  exit 1
+fi
+print_success "Project number: $PROJECT_NUMBER" "Retrieved"
+
+
+# Section 3: Create an Artifact Registry repository
+show_section_header "Creating Artifact Registry repository..."
+show_loading "Creating repository"
+if ! gcloud artifacts repositories describe $SERVICE_NAME-$PROJECT_NUMBER-repo --location=$AR_LOCATION > /dev/null 2>&1; then
+    gcloud artifacts repositories create $SERVICE_NAME-$PROJECT_NUMBER-repo \
+        --repository-format=docker \
+        --location=$AR_LOCATION \
+        --description="DESCRIPTION" \
+        --async
+    if [ $? -ne 0 ]; then
+        print_error "$SERVICE_NAME-$PROJECT_NUMBER-repo repository creation" "Failed"
+        exit 1
+    else
+        print_success "$SERVICE_NAME-$PROJECT_NUMBER-repo repository" "Created"
+    fi
+else
+    print_warning "$SERVICE_NAME-$PROJECT_NUMBER-repo repository already exists" "Skipped"
+fi
+
+# Section 4: GCS Bucket Creation
+show_section_header "Creating Cloud Storage bucket..."
+show_loading "Creating bucket"
+if ! gcloud storage buckets describe gs://$SERVICE_NAME-$PROJECT_NUMBER-bucket --format="json(name)" > /dev/null 2>&1; then
+    gcloud storage buckets create gs://$SERVICE_NAME-$PROJECT_NUMBER-bucket \
+        --project=$GCP_PROJECT_ID \
+        --default-storage-class=standard \
+        --location=$GCP_BUCKET_LOCATION
+
+    if [ $? -ne 0 ]; then
+        print_error "gs://$SERVICE_NAME-$PROJECT_NUMBER-bucket creation" "Failed"
+    else
+        print_success "gs://$SERVICE_NAME-$PROJECT_NUMBER-bucket bucket" "Created"
+    fi
+else
+    print_warning "gs://$SERVICE_NAME-$PROJECT_NUMBER-bucket bucket already exists" "Skipped"
+fi
+
+# Section 5: Cloud SQL for MySQL instance creation
+show_section_header "Creating Cloud SQL for MySQL instance..."
+show_loading "Creating MySQL instance"
+if ! gcloud sql instances describe $SERVICE_NAME-$PROJECT_NUMBER-mysql > /dev/null 2>&1; then
+    gcloud sql instances create $SERVICE_NAME-$PROJECT_NUMBER-mysql \
+        --database-version=MYSQL_8_0 \
+        --cpu=2 \
+        --memory=3840MB \
+        --region=$GCP_REGION \
+        --availability-type=ZONAL
+
+    if [ $? -ne 0 ]; then
+        print_error "$SERVICE_NAME-$PROJECT_NUMBER-mysql instance creation" "Failed"
+    else
+        print_success "$SERVICE_NAME-$PROJECT_NUMBER-mysql instance" "Created"
+    fi
+else
+    print_warning "$SERVICE_NAME-$PROJECT_NUMBER-mysql instance already exists" "Skipped"
+fi
+
+echo -e "\nGoogle Cloud environment setup completed successfully.\n"

--- a/deploy-new/setup-gcp-loadbalancer.sh
+++ b/deploy-new/setup-gcp-loadbalancer.sh
@@ -1,0 +1,288 @@
+#!/bin/bash
+
+# Create and Generate Service Account Key, save it as 'sa_key.json' in the root folder with the following IAM Permissions:
+# Network Admin             # Create load balancer components
+# Compute Security Admin    # Create Google-managed SSL certificates
+# DNS Administrator         # To manage Cloud DNS
+#
+# You can also using your own user that has Owner/Editor permissions
+# Comment `gcloud auth login --cred-file="$PARENT_DIR/sa_key.json"` command below
+# Make sure you have already setup gcloud SDK (gcloud CLI) and login with your account
+# Documentation : https://cloud.google.com/sdk/docs/authorizing
+
+# Define required environment variables for this script
+required_vars=("GCP_PROJECT_ID" "GCP_REGION" "GCP_DNS_ZONE_NAME" "SERVICE_ACCOUNT_NAME" "SERVICE_NAME" "DOMAIN_NAME")
+
+# Set Path
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Validate environment variables or exit
+source "$SCRIPT_DIR/common.sh"
+
+# Section 1: Setup gcloud CLI using Service Account Key
+show_section_header "Setting up gcloud CLI permissions using Service Account..."
+show_loading "Configuring gcloud CLI with Service Account"
+gcloud auth activate-service-account $SERVICE_ACCOUNT_NAME@$GCP_PROJECT_ID.iam.gserviceaccount.com \
+    --key-file="$SCRIPT_DIR/$SERVICE_ACCOUNT_NAME.json" \
+    --project=$GCP_PROJECT_ID
+
+if [ $? -ne 0 ]; then
+    print_error "Configure gcloud CLI with Service Account" "Failed"
+    exit 1
+fi
+print_success "Configure gcloud CLI with Service Account" "Success"
+
+# Get Project Number
+show_loading "Get GCP Project number"
+PROJECT_NUMBER=$(gcloud projects describe $GCP_PROJECT_ID --format="value(projectNumber)")
+if [ $? -ne 0 ]; then
+  print_error "Retrieving project number" "Failed"
+  exit 1
+fi
+print_success "Project number: $PROJECT_NUMBER" "Retrieved"
+
+
+# Section 2: Setup IP, DNS, SSL Certificate
+show_section_header "Setup IP and DNS..."
+show_loading "Reserving global static external IP..."
+echo "Reserving global static external IP address for Loadbalancer..."
+if ! gcloud compute addresses describe $SERVICE_NAME-$PROJECT_NUMBER-ip --global > /dev/null 2>&1; then
+    gcloud compute addresses create $SERVICE_NAME-$PROJECT_NUMBER-ip \
+        --network-tier=PREMIUM \
+        --ip-version=IPV4 \
+        --global
+    if [ $? -ne 0 ]; then
+        print_error "$SERVICE_NAME-$PROJECT_NUMBER-ip IP creation" "Failed"
+        exit 1
+    else
+        print_success "$SERVICE_NAME-$PROJECT_NUMBER-ip IP" "Created"
+    fi
+else
+    print_warning "$SERVICE_NAME-$PROJECT_NUMBER-ip IP already exists" "Skipped"
+fi
+
+# Set the IP address as environment variable
+show_loading "Fetching static IP address..."
+STATIC_IP=$(gcloud compute addresses describe $SERVICE_NAME-$PROJECT_NUMBER-ip \
+    --format="get(address)" \
+    --global 2>/dev/null)
+echo "Static IP: $STATIC_IP"
+
+# Create DNS zone if it doesn't exist
+show_loading "Creating DNS zone..."
+if ! gcloud dns managed-zones describe $GCP_DNS_ZONE_NAME > /dev/null 2>&1; then
+    gcloud dns managed-zones create $GCP_DNS_ZONE_NAME --dns-name="$DOMAIN_NAME." --description="DNS zone for $DOMAIN_NAME"
+
+    if [ $? -ne 0 ]; then
+        print_error "$GCP_DNS_ZONE_NAME DNS Zone creation" "Failed"
+        exit 1
+    else
+        print_success "$GCP_DNS_ZONE_NAME DNS Zone" "Created"
+
+        # Add a DNS record set for your domain, ww.domain, and dev.domain
+        show_loading "Creating DNS record..."
+        if ! gcloud dns record-sets describe $DOMAIN_NAME. --type=A --zone=$GCP_DNS_ZONE_NAME > /dev/null 2>&1; then
+            gcloud dns record-sets create $DOMAIN_NAME. \
+                --zone="$GCP_DNS_ZONE_NAME" \
+                --type="A" \
+                --ttl="300" \
+                --rrdatas="$STATIC_IP"
+            if [ $? -ne 0 ]; then
+                print_error "$GCP_DNS_ZONE_NAME DNS Zone creation" "Failed"
+                exit 1
+            else
+                print_success "$GCP_DNS_ZONE_NAME DNS Zone" "Created"
+            fi
+        else
+            print_warning "$DOMAIN_NAME DNS record already exists" "Skipped"
+        fi
+    fi
+else
+    print_warning "$GCP_DNS_ZONE_NAME DNS Zone already exists" "Skipped"
+fi
+
+# Create SSL Certificate for Loadbalancer
+show_loading "Creating SSL certificate..."
+if ! gcloud compute ssl-certificates describe $SERVICE_NAME-$PROJECT_NUMBER-ssl --global > /dev/null 2>&1; then
+    gcloud compute ssl-certificates create $SERVICE_NAME-$PROJECT_NUMBER-ssl \
+        --description="SSL Certificate for Loadbalancer" \
+        --domains=$DOMAIN_NAME \
+        --global
+    if [ $? -ne 0 ]; then
+        print_error "$SERVICE_NAME-$PROJECT_NUMBER-ssl certificate creation" "Failed"
+        exit 1
+    else
+        print_success "$SERVICE_NAME-$PROJECT_NUMBER-ssl certificate" "Created"
+    fi
+else
+    print_warning "$SERVICE_NAME-$PROJECT_NUMBER-ssl certificate already exists" "Skipped"
+fi
+
+
+# Section 3: Setup Backend Services
+# Create a serverless NEG
+show_section_header "Setup Backend services..."
+show_loading "Creating serverless NEG..."
+if ! gcloud compute network-endpoint-groups describe $SERVICE_NAME-$PROJECT_NUMBER-neg --region=$GCP_REGION > /dev/null 2>&1; then
+    gcloud compute network-endpoint-groups create $SERVICE_NAME-$PROJECT_NUMBER-neg \
+        --region=$GCP_REGION \
+        --network-endpoint-type=serverless  \
+        --cloud-run-service=$SERVICE_NAME
+    if [ $? -ne 0 ]; then
+        print_error "$SERVICE_NAME-$PROJECT_NUMBER-neg NEG creation" "Failed"
+        exit 1
+    else
+        print_success "$SERVICE_NAME-$PROJECT_NUMBER-neg NEG" "Created"
+    fi
+else
+    print_warning "$SERVICE_NAME-$PROJECT_NUMBER-neg NEG already exists" "Skipped"
+fi
+
+# Create a backend service
+show_loading "Creating a Backend Service..."
+if ! gcloud compute backend-services describe $SERVICE_NAME-$PROJECT_NUMBER-bs --global > /dev/null 2>&1; then
+    gcloud compute backend-services create $SERVICE_NAME-$PROJECT_NUMBER-bs \
+        --load-balancing-scheme=EXTERNAL_MANAGED \
+        --global
+    if [ $? -ne 0 ]; then
+        print_error "$SERVICE_NAME-$PROJECT_NUMBER-bs backend service creation" "Failed"
+        exit 1
+    else
+        print_success "$SERVICE_NAME-$PROJECT_NUMBER-bs backend service" "Created"
+        # Add serverless NEG to the backend service
+        show_loading "Adding serverless NEG to the backend service..."
+        if [[ $(gcloud compute backend-services list --filter="name:( $SERVICE_NAME-$PROJECT_NUMBER-bs )" --global) == Listed* ]] then
+            gcloud compute backend-services add-backend $SERVICE_NAME-$PROJECT_NUMBER-bs \
+                --global \
+                --network-endpoint-group=$SERVICE_NAME-$PROJECT_NUMBER-neg \
+                --network-endpoint-group-region=$GCP_REGION
+            if [ $? -ne 0 ]; then
+                print_error "Adding $SERVICE_NAME-$PROJECT_NUMBER-neg to backend service" "Failed"
+                exit 1
+            else
+                print_success "Adding $SERVICE_NAME-$PROJECT_NUMBER-neg to backend service" "Success"
+            fi
+        else
+            print_warning "$SERVICE_NAME-$PROJECT_NUMBER-neg already added" "Skipped"
+        fi
+    fi
+else
+    print_warning "$SERVICE_NAME-$PROJECT_NUMBER-bs backend service already exists" "Skipped"
+fi
+
+
+# Section 4: URL map
+# Create a URL map to route incoming requests to the backend service
+show_section_header "Setup URL map..."
+show_loading "Creating default URL map..."
+if ! gcloud compute url-maps describe $SERVICE_NAME-$PROJECT_NUMBER-url-map > /dev/null 2>&1; then
+gcloud compute url-maps create $SERVICE_NAME-$PROJECT_NUMBER-url-map \
+    --default-service $SERVICE_NAME-$PROJECT_NUMBER-bs \
+    --global
+    if [ $? -ne 0 ]; then
+        print_error "$SERVICE_NAME-$PROJECT_NUMBER-url-map URL map creation" "Failed"
+        exit 1
+    else
+        print_success "$SERVICE_NAME-$PROJECT_NUMBER-url-map URL map" "Created"
+    fi
+else
+    print_warning "$SERVICE_NAME-$PROJECT_NUMBER-url-map URL map already exists" "Skipped"
+fi
+
+# Create a URL map to redirect HTTP to HTTPS
+show_loading "Creating URL map for HTTP to HTTPS redirection..."
+if ! gcloud compute url-maps describe http-to-https-redirect > /dev/null 2>&1; then
+    gcloud compute url-maps import http-to-https-redirect \
+        --source $SCRIPT_DIR/http-to-https.yaml \
+        --global
+    if [ $? -ne 0 ]; then
+        print_error "http-to-https-redirect URL map creation" "Failed"
+        exit 1
+    else
+        print_success "http-to-https-redirect URL map" "Created"
+    fi
+else
+    print_warning "http-to-https-redirect URL map already exists" "Skipped"
+fi
+
+
+# Section 5: Target Proxy
+# Create HTTP target proxy
+show_section_header "Setup Target Proxy..."
+show_loading "Creating HTTP target proxy..."
+if ! gcloud compute target-http-proxies describe $SERVICE_NAME-$PROJECT_NUMBER-http-proxy > /dev/null 2>&1; then
+    gcloud compute target-http-proxies create $SERVICE_NAME-$PROJECT_NUMBER-http-proxy \
+        --url-map=http-to-https-redirect \
+        --global
+    if [ $? -ne 0 ]; then
+        print_error "http-to-https-redirect URL map creation" "Failed"
+        exit 1
+    else
+        print_success "http-to-https-redirect URL map" "Created"
+    fi
+else
+    print_warning "http-to-https-redirect URL map already exists" "Skipped"
+fi
+
+# Create HTTPS target proxy
+show_loading "Creating HTTPS target proxy..."
+if ! gcloud compute target-https-proxies describe $SERVICE_NAME-$PROJECT_NUMBER-https-proxy > /dev/null 2>&1; then
+    gcloud compute target-https-proxies create $SERVICE_NAME-$PROJECT_NUMBER-https-proxy \
+        --ssl-certificates=$SERVICE_NAME-$PROJECT_NUMBER-ssl \
+        --url-map=$SERVICE_NAME-$PROJECT_NUMBER-url-map \
+        --global
+    if [ $? -ne 0 ]; then
+        print_error "http-to-https-redirect URL map creation" "Failed"
+        exit 1
+    else
+        print_success "http-to-https-redirect URL map" "Created"
+    fi
+else
+    print_warning "http-to-https-redirect URL map already exists" "Skipped"
+fi
+
+
+# Section 6: Forwarding Rules
+# Create HTTP load balancer
+show_section_header "Setup Forwarding Rules..."
+show_loading "Creating HTTP load balancer..."
+if ! gcloud compute forwarding-rules describe $SERVICE_NAME-$PROJECT_NUMBER-http-lb --global > /dev/null 2>&1; then
+    gcloud compute forwarding-rules create $SERVICE_NAME-$PROJECT_NUMBER-http-lb \
+        --load-balancing-scheme=EXTERNAL_MANAGED \
+        --network-tier=PREMIUM \
+        --address=$SERVICE_NAME-$PROJECT_NUMBER-ip \
+        --target-http-proxy=$SERVICE_NAME-$PROJECT_NUMBER-http-proxy \
+        --global \
+        --ports=80
+    if [ $? -ne 0 ]; then
+        print_error "$SERVICE_NAME-$PROJECT_NUMBER-http-lb forwarding rule creation" "Failed"
+        exit 1
+    else
+        print_success "$SERVICE_NAME-$PROJECT_NUMBER-http-lb"forwarding rule  "Created"
+    fi
+else
+    print_warning "$SERVICE_NAME-$PROJECT_NUMBER-http-lb forwarding rule already exists" "Skipped"
+fi
+
+# Create HTTPS load balancer
+show_loading "Creating HTTPS load balancer..."
+if ! gcloud compute forwarding-rules describe $SERVICE_NAME-$PROJECT_NUMBER-https-lb --global  > /dev/null 2>&1; then
+    gcloud compute forwarding-rules create $SERVICE_NAME-$PROJECT_NUMBER-https-lb \
+        --load-balancing-scheme=EXTERNAL_MANAGED \
+        --network-tier=PREMIUM \
+        --address=$SERVICE_NAME-$PROJECT_NUMBER-ip \
+        --target-https-proxy=$SERVICE_NAME-$PROJECT_NUMBER-https-proxy \
+        --global \
+        --ports=443
+    if [ $? -ne 0 ]; then
+        print_error "$SERVICE_NAME-$PROJECT_NUMBER-https-lb Forwarding rule creation" "Failed"
+        exit 1
+    else
+        print_success "$SERVICE_NAME-$PROJECT_NUMBER-https-lb Forwarding rule" "Created"
+    fi
+else
+    print_warning "$SERVICE_NAME-$PROJECT_NUMBER-https-lb Forwarding rule already exists" "Skipped"
+fi
+
+
+echo -e "\nGCP Load balancer setup completed.\n"

--- a/env.example
+++ b/env.example
@@ -1,26 +1,17 @@
-GCP_PROJECT_ID=                             # Google Cloud Project ID
-GCP_REGION=                                 # Google Cloud Region
-AR_REPO_NAME=                               # Artifcat Registry Repository name
-AR_LOCATION=                                # Artifcat Registry Repository location
-SERVICE_NAME=                               # Cloud Run service name
-CLOUD_SQL_CONN=                             # Cloud SQL for MySQL Connection name
-GCP_DNS_ZONE_NAME=                          # Cloud DNS Zone name
-DOMAIN_NAME=                                # Domain name used for Load Balancer and Cloud DNS
+GCP_PROJECT_ID=
+GCP_REGION=
+AR_LOCATION=
+GCP_DNS_ZONE_NAME=
+GCP_BUCKET_LOCATION=
+SERVICE_ACCOUNT_NAME=
 
 # Django Settings
-DJANGO_ALLOWED_HOSTS=                       # Comma separated values
-DJANGO_CSRF_TRUSTED_ORIGINS=                # Comma separated values
+SERVICE_NAME=
+DOMAIN_NAME=
+MYSQL_ROOT_PASSWORD=
+MYSQL_USER_PASSWORD=
+DJANGO_ALLOWED_HOSTS=.run.app,test.blogdoang.com
+DJANGO_CSRF_TRUSTED_ORIGINS=https://*.run.app,https://test.blogdoang.com
 
-# Cloud Run Environment Variables
-DJANGO_ENV=                                 # Set it to 'development' or 'production'
-
-# Cloud Run Secrets
-# Before you set the below values, please make sure you have created all the Secrets in Secret Manager GCP
-DJANGO_SECRET_KEY=                          # example DJANGO_SECRET_KEY:latest
-DJANGO_SUPERUSER_USERNAME=                  # example DJANGO_SUPERUSER_USERNAME:latest
-DJANGO_SUPERUSER_PASSWORD=                  # example DJANGO_SUPERUSER_PASSWORD:latest
-DJANGO_SUPERUSER_EMAIL=                     # example DJANGO_SUPERUSER_EMAIL:latest
-MYSQL_HOST=                                 # example MYSQL_HOST:latest
-MYSQL_DATABASE=                             # example MYSQL_DATABASE:latest
-MYSQL_USER=                                 # example MYSQL_USER:latest
-MYSQL_PASSWORD=                             # example MYSQL_PASSWORD:latest
+# Cloud Run Environment Variables (production or development)
+DJANGO_ENV=


### PR DESCRIPTION
You have to run the script starting from
1. http://create-service-account.sh/ (only one time to create service account)
you have to run it and login using your account that has Owner permissions to the project
the script will be generated service account and download service account key to folder deploy-new/[service-account-name].json



2. http://setup-gcp-environment.sh/ (only one time to create all resources)
the script will run and authenticate automatically using deploy-new/[service-account-name].json service account
It will create the following resources:
- Artifact Registry Repository
- GCS Bucket
- Cloud SQL for MySQL instance



3. http://build-and-deploy.sh/ (you can run multiple times to update the cloud run if you made changes to your application)
the script will create necessary Secret in Secret Manager, build the container and deploy it to cloud run



4. setup-gcp-loadbalancer (only one time to create load balancer, but it's depend on cloud run that's why it execute it last)
the script will setup DNS, SSL Certificate and Load balancer